### PR TITLE
Remove strong dependency check for mbstring

### DIFF
--- a/String.php
+++ b/String.php
@@ -216,7 +216,7 @@ class String implements \ArrayAccess, \Countable, \IteratorAggregate {
      */
     public function __construct ( $string = null ) {
 
-        if(false === extension_loaded('mbstring'))
+        if(false === function_exists('mb_strlen'))
             throw new Exception(
                 '%s needs the mbstring extension.', 0, get_class($this));
 


### PR DESCRIPTION
The mbstring functions that are used here can be implemented directly in PHP, (see https://github.com/nicolas-grekas/Patchwork-UTF8/blob/master/class/Patchwork/PHP/Shim/Mbstring.php )
but checking for the extension directly excludes this kind of compatibility implementations from working.
