### PR TITLE
`ext/iconv` is suggested, no longer required

### DIFF
--- a/Test/Unit/Issue.php
+++ b/Test/Unit/Issue.php
@@ -36,8 +36,8 @@
 
 namespace Hoa\Ustring\Test\Unit;
 
-use Hoa\Ustring as LUT;
 use Hoa\Test;
+use Hoa\Ustring as LUT;
 
 /**
  * Class \Hoa\Ustring\Test\Unit\Issue.

--- a/Test/Unit/Search.php
+++ b/Test/Unit/Search.php
@@ -36,8 +36,8 @@
 
 namespace Hoa\Ustring\Test\Unit;
 
-use Hoa\Ustring as LUT;
 use Hoa\Test;
+use Hoa\Ustring as LUT;
 
 /**
  * Class \Hoa\Ustring\Test\Unit\Search.

--- a/Test/Unit/Ustring.php
+++ b/Test/Unit/Ustring.php
@@ -36,8 +36,8 @@
 
 namespace Hoa\Ustring\Test\Unit;
 
-use Hoa\Ustring as LUT;
 use Hoa\Test;
+use Hoa\Ustring as LUT;
 
 /**
  * Class \Hoa\Ustring\Test\Unit\Ustring.
@@ -49,7 +49,16 @@ use Hoa\Test;
  */
 class Ustring extends Test\Unit\Suite
 {
-    public function case_no_mbstring()
+    public function case_check_mbstring()
+    {
+        $this
+            ->given($this->function->function_exists = true)
+            ->then
+                ->boolean(LUT::checkMbString())
+                    ->isTrue();
+    }
+
+    public function case_check_no_mbstring()
     {
         $this
             ->given(

--- a/Test/Unit/Ustring.php
+++ b/Test/Unit/Ustring.php
@@ -901,6 +901,20 @@ class Ustring extends Test\Unit\Suite
                     ->isEqualTo('11110000100111111001001010101001');
     }
 
+    public function case_transcode_no_iconv()
+    {
+        $this
+            ->given(
+                $this->function->function_exists = function ($name) {
+                    return 'iconv' !== $name;
+                }
+            )
+            ->exception(function () {
+                LUT::transcode('foo', 'UTF-8');
+            })
+                ->isInstanceOf('Hoa\Ustring\Exception');
+    }
+
     public function case_transcode_and_isUtf8()
     {
         $this

--- a/Ustring.php
+++ b/Ustring.php
@@ -204,19 +204,21 @@ class Ustring implements \ArrayAccess, \Countable, \IteratorAggregate
      */
     public function __construct($string = null)
     {
-        if (false === function_exists('mb_substr')) {
-            throw new Exception(
-                '%s needs the mbstring extension.',
-                0,
-                get_class($this)
-            );
-        }
-
         if (null !== $string) {
             $this->append($string);
         }
 
         return;
+    }
+
+    /**
+     * Check if ext/mbstring is available.
+     *
+     * @return  bool
+     */
+    public static function checkMbString()
+    {
+        return function_exists('mb_substr');
     }
 
     /**
@@ -504,7 +506,7 @@ class Ustring implements \ArrayAccess, \Countable, \IteratorAggregate
                 throw new Exception(
                     '%s needs the class Normalizer to work properly, ' .
                     'or you can force a try by using %1$s(true).',
-                    1,
+                    0,
                     __METHOD__
                 );
             }
@@ -537,7 +539,7 @@ class Ustring implements \ArrayAccess, \Countable, \IteratorAggregate
         if (null === $transliterator = static::getTransliterator($identifier)) {
             throw new Exception(
                 '%s needs the class Transliterator to work properly.',
-                2,
+                1,
                 __METHOD__
             );
         }
@@ -1035,3 +1037,11 @@ class Ustring implements \ArrayAccess, \Countable, \IteratorAggregate
  * Flex entity.
  */
 Core\Consistency::flexEntity('Hoa\Ustring\Ustring');
+
+if (false === Ustring::checkMbString()) {
+    throw new Exception(
+        '%s needs the mbstring extension.',
+        0,
+        __NAMESPACE__ . '\Ustring'
+    );
+}

--- a/Ustring.php
+++ b/Ustring.php
@@ -222,6 +222,16 @@ class Ustring implements \ArrayAccess, \Countable, \IteratorAggregate
     }
 
     /**
+     * Check if ext/iconv is available.
+     *
+     * @return  bool
+     */
+    public static function checkIconv()
+    {
+        return function_exists('iconv');
+    }
+
+    /**
      * Append a substring to the current string, i.e. add to the end.
      *
      * @param   string  $substring    Substring to append.
@@ -995,9 +1005,18 @@ class Ustring implements \ArrayAccess, \Countable, \IteratorAggregate
      * @param   string  $from      Original encoding.
      * @param   string  $to        Final encoding.
      * @return  string
+     * @throws  \Hoa\Ustring\Exception
      */
     public static function transcode($string, $from, $to = 'UTF-8')
     {
+        if (false === static::checkIconv()) {
+            throw new Exception(
+                '%s needs the iconv extension.',
+                2,
+                __CLASS__
+            );
+        }
+
         return iconv($from, $to, $string);
     }
 

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,7 @@
         "source": "http://git.hoa-project.net/"
     },
     "require": {
-        "hoa/core"    : "~2.0",
-        "ext-iconv"   : "*"
+        "hoa/core": "~2.0"
     },
     "require-dev": {
         "hoa/test": "~1.0"
@@ -33,7 +32,8 @@
         }
     },
     "suggest": {
-        "ext-intl": "To get a better Hoa\\Ustring::toAscii() and Hoa\\Ustring::compareTo()."
+        "ext-iconv": "ext/iconv must be present (or a third implementation) to use Hoa\\Ustring::transcode().",
+        "ext-intl" : "To get a better Hoa\\Ustring::toAscii() and Hoa\\Ustring::compareTo()."
     },
     "extra"     : {
         "branch-alias": {


### PR DESCRIPTION
Fix #31.

First, this patch introduces and testes the `checkIconv` static method that checks whether the `ext/iconv` extension is available or not.

Second, this method is used in the `Ustring::transcode` static method to test whether this extension is available. If not, then an exception is thrown.

Finally, because this is only for one method **and** to allow third implementation to be used instead of the official `ext/iconv` extension, this extension is now suggested instead of required in the `composer.json` file. It removes one (strong) dependency to projects using `hoa/ustring` if they are sure to not use `Hoa\Ustring::transcode`.