### PR TITLE
Fixed leftover typos (string -> ustring)

### DIFF
--- a/Bin/Fromcode.php
+++ b/Bin/Fromcode.php
@@ -107,7 +107,7 @@ class Fromcode extends Console\Dispatcher\Kit
     public function usage()
     {
         echo
-            'Usage   : string:fromcode <char>', "\n",
+            'Usage   : ustring:fromcode <char>', "\n",
             'Options :', "\n",
             $this->makeUsageOptionsList([
                 'b'    => 'Specify the base of the code (16 by default).',

--- a/Bin/Tocode.php
+++ b/Bin/Tocode.php
@@ -107,7 +107,7 @@ class Tocode extends Console\Dispatcher\Kit
     public function usage()
     {
         echo
-            'Usage   : string:tocode <char>', "\n",
+            'Usage   : ustring:tocode <char>', "\n",
             'Options :', "\n",
             $this->makeUsageOptionsList([
                 'b'    => 'Get the code in a specific base (16 by default).',

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ algorithms.
 
 With [Composer](http://getcomposer.org/), to include this library into your
 dependencies, you need to require
-[`hoa/string`](https://packagist.org/packages/hoa/string):
+[`hoa/ustring`](https://packagist.org/packages/hoa/ustring):
 
 ```json
 {


### PR DESCRIPTION
Converted all leftover mentions of the old "string" repository to "ustring" (documentation only).